### PR TITLE
Center media section

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -18,6 +18,14 @@ html, body, #timeline-embed {
 	font-size: 1.2em;
 }
 
+.tl-slide .tl-slide-content-container .tl-slide-content .tl-media {
+	width: 50%;
+	max-width: 50%;
+	float: none;
+    display: table-cell;
+    vertical-align: middle;
+}
+
 // Timeline Era backgrounds
 .tl-timeera.tl-timeera-color0 .tl-timeera-background {
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -22,8 +22,8 @@ html, body, #timeline-embed {
 	width: 50%;
 	max-width: 50%;
 	float: none;
-    display: table-cell;
-    vertical-align: middle;
+	display: table-cell;
+	vertical-align: middle;
 }
 
 // Timeline Era backgrounds


### PR DESCRIPTION
## Summary
Fixes issue [#42](https://github.com/L4GG/timeline/issues/42)
This PR vertically centers the media section on the left (videos, images, quotes). It uses `display: table-cell` to do this, keeping the centering consistent with the rest of the Timeline CSS. 

[Before](https://cloud.githubusercontent.com/assets/5424713/25967488/f5857c9a-3653-11e7-99b6-670d6ae4560c.png)
![Before](https://cloud.githubusercontent.com/assets/5424713/25967488/f5857c9a-3653-11e7-99b6-670d6ae4560c.png)
[After](https://cloud.githubusercontent.com/assets/5424713/25967462/e10ecf46-3653-11e7-88d1-a0ed631d8ae8.png)
![After](https://cloud.githubusercontent.com/assets/5424713/25967462/e10ecf46-3653-11e7-88d1-a0ed631d8ae8.png)