### PR TITLE
Fix links 2017 09 07

### DIFF
--- a/src/events/2014/trump-putin-does-not-respect-us/slide-text.html
+++ b/src/events/2014/trump-putin-does-not-respect-us/slide-text.html
@@ -16,6 +16,6 @@
 	the other side to respect you, and he does not respect our president, which is
 	very sad.”
 </p>
-<a href="http://www.press.org/speakers/transcripts-2014">Source: National Press Club</a>
+<a href="http://www.press.org/sites/default/files/20140527_trump.pdf">Source: National Press Club</a>
 <br>
 <a href="https://ig.ft.com/sites/trumps-russian-connections/">Source: Financial Times</a>

--- a/src/events/2014/trump-putin-does-not-respect-us/slide-text.html
+++ b/src/events/2014/trump-putin-does-not-respect-us/slide-text.html
@@ -16,6 +16,6 @@
 	the other side to respect you, and he does not respect our president, which is
 	very sad.”
 </p>
-<a href="http://cfc.press.org/members/transcript/20140527_trump.pdf">Source: National Press Club</a>
+<a href="http://www.press.org/speakers/transcripts-2014">Source: National Press Club</a>
 <br>
 <a href="https://ig.ft.com/sites/trumps-russian-connections/">Source: Financial Times</a>

--- a/src/events/2016/trump-defends-russia-at-second-debate/slide-text.html
+++ b/src/events/2016/trump-defends-russia-at-second-debate/slide-text.html
@@ -5,6 +5,6 @@
   with Russia. I know about Russia, but I know nothing about the inner workings
   of Russia. I have no businesses, I have no loans from Russia.”
 </p>
-<a href="https://www.nytimes.com/2016/10/10/us/politics/transcript-second-debate.htm">Source: New York Times</a>
+<a href="https://www.nytimes.com/2016/10/10/us/politics/transcript-second-debate.html">Source: New York Times</a>
 <br>
 <a href="https://ig.ft.com/sites/trumps-russian-connections/">Source: Financial Times</a>


### PR DESCRIPTION
There are two links failing tests on master.

I'm not sure what the normal process is for correcting this.  If we succeed in sourcing events from AirTable this change will be redundant, but I like it when tests are passing.

## 2016/trump-defends-russia-at-second-debate

This one looks like it was a typo that snuck in.  It's also possible that the nytimes changed something in their webserver such that `.htm` links don't resolve to `.html` automatically, anymore.

## 2014/trump-putin-does-not-respect-us

I'm not really sure what to do here.  It seems like the actual link is broken in the National Press Club archive.  I filled out their contact form requesting a fix.  In the meantime, maybe we change the link to the listing so that people can find the video recording at least?